### PR TITLE
Cryptopia: Fallback to FilledOrders if OrderId does not exist

### DIFF
--- a/js/cryptopia.js
+++ b/js/cryptopia.js
@@ -621,8 +621,12 @@ module.exports = class cryptopia extends Exchange {
                     status = 'closed';
                 }
             }
-            if (!id && ('FilledOrders' in response['Data'])) {
-                id = response['Data']['FilledOrders'].toString ();
+            if (
+                !id &&
+                'FilledOrders' in response['Data'] &&
+                response['Data']['FilledOrders'].length > 0
+            ) {
+                id = response['Data']['FilledOrders'][0].toString ();
             }
         }
         let order = {


### PR DESCRIPTION
For some trades, cryptopia does not return and `OrderId`. This pr falls back to using the first ID from `FilledOrders`